### PR TITLE
Add user-aware rate limiting

### DIFF
--- a/src/app/api/middleware/authentication.py
+++ b/src/app/api/middleware/authentication.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+import jwt
+from fastapi import FastAPI, Request, Response
+
+
+def install_auth_middleware(app: FastAPI) -> None:
+    @app.middleware("http")
+    async def auth_middleware(
+        request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
+        request.state.user_id = None
+        auth_header = request.headers.get("authorization") or ""
+        if auth_header.lower().startswith("bearer "):
+            token = auth_header.split(" ", 1)[1]
+            try:
+                payload = jwt.decode(token, options={"verify_signature": False})
+                user_id = payload.get("oid") or payload.get("sub") or payload.get("user_id")
+                if isinstance(user_id, str) and user_id:
+                    request.state.user_id = user_id
+            except Exception:
+                pass
+        return await call_next(request)

--- a/tests/test_rate_limiter_middleware.py
+++ b/tests/test_rate_limiter_middleware.py
@@ -8,7 +8,9 @@ logger = logging.getLogger(__name__)
 
 
 class DummyLimiter:
-    async def check_rate_limit(self, request: Request) -> None:  # pragma: no cover - stub
+    async def check_rate_limit(
+        self, request: Request, user_id: str | None = None
+    ) -> None:  # pragma: no cover - stub
         return None
 
 
@@ -17,8 +19,11 @@ app = FastAPI()
 
 
 @app.middleware("http")
-async def _rl_mw(request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
-    await limiter.check_rate_limit(request)
+async def _rl_mw(
+    request: Request, call_next: Callable[[Request], Awaitable[Response]]
+) -> Response:
+    user_id = getattr(request.state, "user_id", None)
+    await limiter.check_rate_limit(request, user_id)
     try:
         return await call_next(request)
     except Exception as exc:  # pragma: no cover - defensive


### PR DESCRIPTION
## Summary
- add middleware to extract user ID from bearer token
- forward extracted user ID to rate limiter
- adjust rate limiter tests for user-aware calls

## Testing
- `pytest -q --override-ini=addopts=`

------
https://chatgpt.com/codex/tasks/task_b_68a4bdcd459c832d8d8e53a6a2c6668e