### PR TITLE
Log auth retrieval errors before using mock user

### DIFF
--- a/src/app/api/routes/chat.py
+++ b/src/app/api/routes/chat.py
@@ -55,8 +55,9 @@ async def get_optional_user(request: Request) -> Any:
     if AUTH_AVAILABLE:
         try:
             return await get_current_active_user()
-        except:
+        except Exception as exc:
             if IS_DEVELOPMENT:
+                logger.exception("Failed to retrieve current user: %s", exc)
                 return type(
                     "User",
                     (),


### PR DESCRIPTION
## Summary
- log exception if authentication lookup fails and fall back to mock user in development

## Testing
- `pytest -o addopts=''`


------
https://chatgpt.com/codex/tasks/task_b_68a4bd785cc4832db46fabad4034f429