### PR TITLE
Rename NLU parser types to PascalCase

### DIFF
--- a/src/app/ai/nlu/__init__.py
+++ b/src/app/ai/nlu/__init__.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from .unified_parser import (
-    deployment_intent,
+    DeploymentIntent,
     maybe_map_provision,
     parse_action,
     parse_provision_request,
     unified_nlu_parser,
-    unified_parse_result,
+    UnifiedParseResult,
 )
 
 NLPParser = unified_nlu_parser
@@ -14,8 +14,8 @@ NLPParser = unified_nlu_parser
 
 __all__ = [
     "unified_nlu_parser",
-    "unified_parse_result",
-    "deployment_intent",
+    "UnifiedParseResult",
+    "DeploymentIntent",
     "parse_provision_request",
     "parse_action",
     "maybe_map_provision",


### PR DESCRIPTION
## Summary
- rename `deployment_intent` to `DeploymentIntent`
- rename `unified_parse_result` to `UnifiedParseResult`
- adjust imports and exports for new names

## Testing
- `mypy src` (fails: Name "User" already defined; Function is missing a return type annotation)
- `pytest -q -o addopts=""`


------
https://chatgpt.com/codex/tasks/task_b_68a4bdbb80a8832da28808f8cac8f029