### PR TITLE
refactor: fix get_logger import paths

### DIFF
--- a/src/app/api/security/entra.py
+++ b/src/app/api/security/entra.py
@@ -15,7 +15,7 @@ from fastapi import HTTPException, Request, status
 from fastapi.security import HTTPBearer
 from jwt import PyJWTError
 from jwt.algorithms import RSAAlgorithm
-from src.app.core.loging import get_logger
+from app.core.loging import get_logger
 
 from app.api.schemas import TokenData
 from app.observability.tracing import get_tracer

--- a/src/app/memory/storage.py
+++ b/src/app/memory/storage.py
@@ -15,7 +15,7 @@ from typing import Any, Literal
 import aiosqlite
 
 from app.core.config import MAX_MEMORY, MAX_TOTAL_MEMORY
-from src.app.core.loging import get_logger
+from app.core.loging import get_logger
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
## Summary
- fix get_logger import paths in security and memory modules
- verify no remaining imports using `src.app` prefix

## Testing
- `pytest -q -o addopts=`

------
https://chatgpt.com/codex/tasks/task_b_68a4c2434d58832dab4ddd746d49113a