### PR TITLE
Handle errors in simple password context verification

### DIFF
--- a/src/app/api/routes/auth.py
+++ b/src/app/api/routes/auth.py
@@ -27,7 +27,8 @@ except Exception:
             try:
                 salt, hash_part = hashed_password.split("$")
                 return hashlib.sha256((salt + plain_password).encode()).hexdigest() == hash_part
-            except:
+            except ValueError as exc:
+                logger.exception("Invalid hashed password: %s", exc)
                 return False
 
     pwd_context = SimplePwdContext()


### PR DESCRIPTION
## Summary
- log invalid hashed password errors in SimplePwdContext.verify

## Testing
- `pip install pytest-cov`
- `pytest --override-ini=addopts=`

------
https://chatgpt.com/codex/tasks/task_b_68a4c3060394832d90480184c0c681e6