### PR TITLE
Log instrumentation initialization errors

### DIFF
--- a/src/app/observability/tracing.py
+++ b/src/app/observability/tracing.py
@@ -11,9 +11,12 @@ from opentelemetry.instrumentation.pymongo import PymongoInstrumentor
 from opentelemetry.sdk.trace import TracerProvider as SDKTracerProvider
 
 from app.core.config import get_settings
+from app.core.loging import get_logger
 
 _configured: bool = False
 _provider: SDKTracerProvider | None = None
+
+logger = get_logger(__name__)
 
 
 def init_tracing(service_name: str = "devops-ai-api") -> None:
@@ -40,25 +43,25 @@ def init_tracing(service_name: str = "devops-ai-api") -> None:
 
     try:
         HTTPXClientInstrumentor().instrument()
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning("HTTPX instrumentation failed", error=str(exc), exc_info=True)
 
     try:
         AsyncPGInstrumentor().instrument()
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning("AsyncPG instrumentation failed", error=str(exc), exc_info=True)
 
     try:
         PymongoInstrumentor().instrument()
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning("Pymongo instrumentation failed", error=str(exc), exc_info=True)
 
     try:
         from opentelemetry.instrumentation.redis import RedisInstrumentor
 
         RedisInstrumentor().instrument()
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning("Redis instrumentation failed", error=str(exc), exc_info=True)
 
     provider = trace.get_tracer_provider()
     if isinstance(provider, SDKTracerProvider):


### PR DESCRIPTION
## Summary
- log failed instrumentation initialization attempts rather than suppressing
- expose tracing startup failures via logger

## Testing
- `pytest -o addopts=''`

------
https://chatgpt.com/codex/tasks/task_b_68a4c2da4018832da3311a26c832f784