### PR TITLE
Raise error on malformed JSON in arg mapper

### DIFF
--- a/src/app/ai/arg_mapper.py
+++ b/src/app/ai/arg_mapper.py
@@ -54,8 +54,8 @@ async def map_args_with_function_call(
             if isinstance(args_raw, str):
                 try:
                     args_obj = json.loads(args_raw)
-                except Exception:
-                    args_obj = {}
+                except json.JSONDecodeError as e:
+                    raise ValueError(e.msg) from e
             elif isinstance(args_raw, dict):
                 args_obj = dict(args_raw)
             else:

--- a/src/app/ai/tools_router.py
+++ b/src/app/ai/tools_router.py
@@ -468,13 +468,16 @@ async def maybe_call_tool(
                 "schema",
                 {"type": "object", "properties": {}, "additionalProperties": True},
             )
-            mapped_args = await map_args_with_function_call(
-                tool_name=preferred_tool,
-                schema=schema,
-                user_input=user_input,
-                provider=provider,
-                model=model,
-            )
+            try:
+                mapped_args = await map_args_with_function_call(
+                    tool_name=preferred_tool,
+                    schema=schema,
+                    user_input=user_input,
+                    provider=provider,
+                    model=model,
+                )
+            except ValueError as e:
+                return f"Invalid tool arguments: {e}"
             if return_json:
                 res = await _run_tool(preferred_tool, mapped_args, context)
                 return json.dumps(res, ensure_ascii=False, indent=2)

--- a/tests/test_arg_mapper.py
+++ b/tests/test_arg_mapper.py
@@ -1,0 +1,57 @@
+import asyncio
+import sys
+import types
+
+import pytest
+
+openai_module = types.ModuleType("openai")
+openai_module.AsyncOpenAI = object
+types_module = types.ModuleType("openai.types")
+chat_module = types.ModuleType("openai.types.chat")
+chat_module.ChatCompletionMessageParam = object
+types_module.chat = chat_module
+openai_module.types = types_module
+sys.modules.setdefault("openai", openai_module)
+sys.modules.setdefault("openai.types", types_module)
+sys.modules.setdefault("openai.types.chat", chat_module)
+
+from app.ai.arg_mapper import map_args_with_function_call
+
+
+class FakeLLM:
+    async def chat_raw(self, **kwargs):
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "tool_calls": [
+                            {
+                                "function": {
+                                    "name": "test",
+                                    "arguments": "{invalid}",
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+
+
+async def fake_get_provider_and_model(provider, model):
+    return FakeLLM(), "model"
+
+
+def test_map_args_with_function_call_invalid_json(monkeypatch):
+    monkeypatch.setattr(
+        "app.ai.arg_mapper.get_provider_and_model", fake_get_provider_and_model
+    )
+
+    async def run() -> None:
+        await map_args_with_function_call(
+            "test", None, "input", None, None
+        )
+
+    with pytest.raises(ValueError) as exc:
+        asyncio.run(run())
+    assert "Expecting property name enclosed in double quotes" in str(exc.value)


### PR DESCRIPTION
## Summary
- raise `ValueError` when JSON tool arguments are malformed
- handle invalid tool arguments in tools router
- test that malformed JSON now raises an error

## Testing
- `pytest -q --override-ini=addopts=`

------
https://chatgpt.com/codex/tasks/task_b_68a4c3206cc8832daf6977efee7b3cef