### PR TITLE
refactor: narrow error types

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -30,9 +30,9 @@ async function fetchWithTimeout(
       throw new ApiError(detail, undefined, res.status);
     }
     return res;
-  } catch (err: any) {
+  } catch (err: unknown) {
     if (err instanceof ApiError) throw err;
-    if (err?.name === "AbortError") {
+    if (err instanceof Error && err.name === "AbortError") {
       throw new ApiError(`${context} timed out`, err);
     }
     throw new ApiError(`${context} error`, err);

--- a/apps/web/src/store/index.ts
+++ b/apps/web/src/store/index.ts
@@ -92,10 +92,18 @@ export const useAuthStore = create<AuthState>()(
               state.token = data.access_token;
               state.isAuthenticated = true;
             });
-          } catch (err: any) {
-            const message =
-              err?.message ||
-              (typeof err?.detail === "string" ? err.detail : "Login failed");
+          } catch (err: unknown) {
+            let message = "Login failed";
+            if (err instanceof Error) {
+              message = err.message;
+            } else if (
+              err &&
+              typeof err === "object" &&
+              "detail" in err &&
+              typeof (err as { detail?: unknown }).detail === "string"
+            ) {
+              message = (err as { detail: string }).detail;
+            }
             throw new Error(message);
           }
         },


### PR DESCRIPTION
## Summary
- replace `any` error types with `unknown`
- safeguard error handling with `instanceof` checks before property access

## Testing
- `pytest` *(fails: unrecognized arguments --cov=src --cov-report=xml --cov-report=term-missing)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68a560c73328832db6d63e70f0e6c7c4