### PR TITLE
Add timeout support to terraform runner

### DIFF
--- a/tests/test_terraform_runner.py
+++ b/tests/test_terraform_runner.py
@@ -1,0 +1,25 @@
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from app.tools.provision.terraform_runner import _run
+
+
+def test_run_success(tmp_path: Path) -> None:
+    code, out = asyncio.run(_run(["bash", "-c", "echo -n success"], tmp_path, timeout=5))
+    assert code == 0
+    assert out == "success"
+
+
+def test_run_failure(tmp_path: Path) -> None:
+    code, out = asyncio.run(
+        _run(["bash", "-c", "echo -n fail; exit 1"], tmp_path, timeout=5)
+    )
+    assert code != 0
+    assert "fail" in out
+
+
+def test_run_timeout(tmp_path: Path) -> None:
+    with pytest.raises(asyncio.TimeoutError):
+        asyncio.run(_run(["bash", "-c", "sleep 2"], tmp_path, timeout=0.1))


### PR DESCRIPTION
## Summary
- avoid hanging subprocesses by adding a timeout to `_run` in `terraform_runner`
- remove redundant wait and rely on `proc.returncode`
- cover success, failure and timeout cases with new tests

## Testing
- `pytest --override-ini="addopts="`

------
https://chatgpt.com/codex/tasks/task_b_68a56f6d5d1c832da30fa445783fb22e