### PR TITLE
Fix OpenAI error messages in OpenAI provider

### DIFF
--- a/src/app/ai/llm/openai_provider.py
+++ b/src/app/ai/llm/openai_provider.py
@@ -74,7 +74,8 @@ class OpenAIProvider(LLMProvider):
                     current.record_exception(err)
                     current.set_status(Status(StatusCode.ERROR, str(err)))
                 raise ExternalServiceException(
-                    "The AI service is busy or unreachable. Please retry. If this keeps happening, try a smaller prompt or wait a minute.",
+                    "The AI service is busy or unreachable. Please retry. If this keeps happening, "
+                    "try a smaller prompt or wait a minute.",
                     retryable=True,
                 ) from err
 
@@ -126,7 +127,8 @@ class OpenAIProvider(LLMProvider):
                     current.record_exception(err)
                     current.set_status(Status(StatusCode.ERROR, str(err)))
                 raise ExternalServiceException(
-                    "The AI service is busy or unreachable. Please retry. If this keeps happening, try a smaller prompt or wait a minute.",
+                    "The AI service is busy or unreachable. Please retry. If this keeps happening, "
+                    "try a smaller prompt or wait a minute.",
                     retryable=True,
                 ) from err
 


### PR DESCRIPTION
## Summary
- ensure OpenAI provider error messages include space and read correctly

## Testing
- `ruff check src/app/ai/llm/openai_provider.py`
- `pytest --override-ini addopts='' -q`


------
https://chatgpt.com/codex/tasks/task_b_68a5ff8ae020832d82c878d0e843f048