### PR TITLE
chore: upgrade lint tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,21 @@ jobs:
           python -m build
           ls -la dist
 
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: apps/web/package-lock.json
+
+      - name: Install web dependencies
+        working-directory: apps/web
+        run: npm ci
+
+      - name: Lint web app
+        working-directory: apps/web
+        run: npm run lint
+
       - name: Ruff lint
         run: ruff check .
 

--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -32,8 +32,8 @@
         "@types/react": "18.3.3",
         "@types/react-dom": "18.3.0",
         "autoprefixer": "10.4.19",
-        "eslint": "8.57.0",
-        "eslint-config-next": "14.2.5",
+        "eslint": "^9.0.0",
+        "eslint-config-next": "^15.0.0",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.17",
         "typescript": "5.4.5"


### PR DESCRIPTION
## Summary
- bump eslint and eslint-config-next to versions compatible with Next 15
- add ESLint config for non-interactive linting
- run web lint in CI via Node setup

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/eslint-config-next)*
- `npm run lint`
- `ruff check .` *(fails: tests/test_rate_limiter_cleanup.py:9:1: E402 Module level import not at top of file)
- `black --check .` *(fails: would reformat /workspace/AzureDeployment_Ai/src/app/ai/agents/__init__.py)
- `mypy src` *(fails: Interrupted)*

------
https://chatgpt.com/codex/tasks/task_b_68a603b936d8832db251298cf9142602