### PR TITLE
feat: require reviewer endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ npm install
 NEXT_PUBLIC_API_BASE_URL=http://localhost:8000 npm run dev
 ```
 
+Set `REVIEWER_ENDPOINT` to the reviewer service URL. Tests can instead enable mock reviews with `REVIEWER_USE_MOCK=true`.
+
 ### Docker for Web
 
 ```bash

--- a/apps/web/src/lib/reviewerClient.ts
+++ b/apps/web/src/lib/reviewerClient.ts
@@ -14,14 +14,22 @@ interface ReviewResponse {
 }
 
 class ReviewerClient {
-    private endpoint: string
+    private endpoint?: string
+    private useMock: boolean
 
     constructor() {
-        this.endpoint = process.env.REVIEWER_ENDPOINT || ''
+        this.endpoint = process.env.REVIEWER_ENDPOINT
+        this.useMock = process.env.REVIEWER_USE_MOCK === 'true'
+
+        if (!this.endpoint && !this.useMock) {
+            throw new Error(
+                'REVIEWER_ENDPOINT is not set. Set the env variable or enable mock mode with REVIEWER_USE_MOCK=true'
+            )
+        }
     }
 
     async review(request: ReviewRequest): Promise<ReviewResponse> {
-        if (!this.endpoint) {
+        if (this.useMock || !this.endpoint) {
             return this.getMockReview(request)
         }
         try {


### PR DESCRIPTION
## Summary
- raise error when `REVIEWER_ENDPOINT` is missing
- add `REVIEWER_USE_MOCK` to enable mock reviews in tests
- document reviewer endpoint requirement

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompts for ESLint setup)*
- `pytest -o addopts=''`


------
https://chatgpt.com/codex/tasks/task_b_68a603b155f4832d806b0b7451ac49e8