### PR TITLE
Handle missing dependencies in inject decorator

### DIFF
--- a/src/app/core/container.py
+++ b/src/app/core/container.py
@@ -323,8 +323,13 @@ def inject(container: Container) -> Callable[[Callable[..., Any]], Callable[...,
                     try:
                         dependency = await container.aget(param.annotation)
                         kwargs[name] = dependency
-                    except Exception:
-                        pass
+                    except LookupError as exc:
+                        logger.warning(
+                            "Dependency %s not found: %s", param.annotation, exc
+                        )
+                        if param.default is inspect.Parameter.empty:
+                            raise
+                        continue
             if asyncio.iscoroutinefunction(func):
                 return await func(*args, **kwargs)
             return func(*args, **kwargs)

--- a/src/app/core/exceptions.py
+++ b/src/app/core/exceptions.py
@@ -200,6 +200,14 @@ class ConfigurationException(BaseApplicationException):
     category = ErrorCategory.CONFIGURATION
 
 
+class ConfigurationError(ConfigurationException, LookupError):
+    """Backward compatible alias for configuration errors."""
+
+    def __init__(self, key: str, message: str):
+        super().__init__(message)
+        self.key = key
+
+
 class CircuitBreakerException(BaseApplicationException):
     severity = ErrorSeverity.ERROR
     category = ErrorCategory.SYSTEM

--- a/tests/test_inject_decorator.py
+++ b/tests/test_inject_decorator.py
@@ -1,0 +1,32 @@
+import asyncio
+
+import pytest
+
+from app.core.container import Container, inject
+from app.core.exceptions import ConfigurationError
+
+
+def test_inject_logs_missing_dependency(caplog: pytest.LogCaptureFixture) -> None:
+    container = Container()
+
+    @inject(container)
+    async def func(dep: int = 5) -> int:
+        return dep
+
+    with caplog.at_level("WARNING"):
+        result = asyncio.run(func())
+
+    assert result == 5
+    assert any("Dependency" in r.message for r in caplog.records)
+
+
+def test_inject_raises_on_missing_required_dependency() -> None:
+    container = Container()
+
+    @inject(container)
+    async def func(dep: int) -> int:
+        return dep
+
+    with pytest.raises(ConfigurationError):
+        asyncio.run(func())
+


### PR DESCRIPTION
## Summary
- log missing dependencies in `inject` decorator and raise when required
- add `ConfigurationError` alias for configuration issues
- test missing dependency logging and error propagation

## Testing
- `pytest --override-ini=addopts=`

------
https://chatgpt.com/codex/tasks/task_b_68a603d01f40832d8a0ac061dc8c0e83