### PR TITLE
Potential fix for code scanning alert no. 10: Incomplete URL substring sanitization

### DIFF
--- a/src/app/observability/app_insights.py
+++ b/src/app/observability/app_insights.py
@@ -11,7 +11,7 @@ from azure.monitor.opentelemetry import configure_azure_monitor
 import logging
 import os
 from typing import Any
-
+from urllib.parse import urlparse
 
 from app.observability.otel_fixes import ensure_proper_otel_initialization
 
@@ -377,8 +377,10 @@ class ApplicationInsights:
                 else:
                     span.set_attribute("http.response.success", False)
 
-            if hasattr(request, "url") and "api.openai.com" in str(request.url):
-                if hasattr(response, "content"):
+            if hasattr(request, "url"):
+                host = urlparse(str(request.url)).hostname
+                if host and host.lower() == "api.openai.com":
+                    if hasattr(response, "content"):
                     try:
                         import json
 


### PR DESCRIPTION
Potential fix for [https://github.com/b-franken/AzureDeployment_Ai/security/code-scanning/10](https://github.com/b-franken/AzureDeployment_Ai/security/code-scanning/10)

To fix the problem, replace any substring checks against the raw URL with checks that parse the URL and examine the `hostname` property. This is best achieved using Python's standard `urllib.parse.urlparse`, which can reliably extract the hostname from a URL string (or, if available, directly from the URL attribute). After parsing, the code should compare the hostname (case-insensitively) to `api.openai.com` (or properly allow subdomain matches if desired, but for a 1:1 replacement here we compare exactly). You'll need to import `urlparse` at the top of the file (from the standard library). Update line 380 and similar occurrences, replacing substring checks with `urlparse().hostname` equality, being sure to handle cases where the hostname may be missing.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
