### PR TITLE
Potential fix for code scanning alert no. 8: Information exposure through an exception

### DIFF
--- a/src/app/api/routes/mcp_integration.py
+++ b/src/app/api/routes/mcp_integration.py
@@ -662,7 +662,7 @@ async def mcp_health_check(td: Annotated[TokenData, Depends(mcp_dependency)]) ->
             health_status = {
                 "status": "unhealthy",
                 "mcp_server": "disconnected",
-                "error": str(e),
+                "error": "An internal error has occurred.",
                 "timestamp": datetime.utcnow().isoformat(),
             }
 


### PR DESCRIPTION
Potential fix for [https://github.com/b-franken/AzureDeployment_Ai/security/code-scanning/8](https://github.com/b-franken/AzureDeployment_Ai/security/code-scanning/8)

To fix this issue, we should never return raw exception messages to the client in the API response. Instead, the `"error"` field in `health_status` should be replaced with a generic message like `"An internal error has occurred"`. Detailed information, such as the real exception and stack trace, should continue to be logged server-side for debugging purposes. Specifically, update lines 662-665 in the exception block to ensure only a generic error message is sent to the client, keeping the timestamp and connectivity info as before. No changes to imports are needed, as all required logging and tracing tools are already present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
