### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,7 +27,8 @@
         "tailwind-merge": "2.5.2",
         "tailwindcss-animate": "1.0.7",
         "zod": "^4.0.17",
-        "zustand": "^4.5.7"
+        "zustand": "^4.5.7",
+        "dompurify": "^3.2.6"
     },
     "devDependencies": {
         "@types/node": "20.12.12",

--- a/apps/web/src/components/chat/MessageContent.tsx
+++ b/apps/web/src/components/chat/MessageContent.tsx
@@ -1,5 +1,6 @@
 // MessageContent.tsx
 import React from 'react'
+import DOMPurify from 'dompurify'
 import { Copy, Check } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 
@@ -157,7 +158,7 @@ const MessageContent: React.FC<MessageContentProps> = ({ content, onCopy }) => {
             key={index}
             className="text-sm leading-relaxed text-black"
             dangerouslySetInnerHTML={{
-              __html: formatText(part.content).replace(/\n/g, '<br>'),
+              __html: DOMPurify.sanitize(formatText(part.content).replace(/\n/g, '<br>')),
             }}
           />
         )


### PR DESCRIPTION
Potential fix for [https://github.com/b-franken/AzureDeployment_Ai/security/code-scanning/5](https://github.com/b-franken/AzureDeployment_Ai/security/code-scanning/5)

To safely render user-controlled input as HTML, **the input must be sanitized before being passed to `dangerouslySetInnerHTML`**. This can be achieved by using a well-maintained HTML sanitization library such as `dompurify`. The most robust and least error-prone solution is:

- After markdown/formatting transformations (`formatText`), but before passing the string to `dangerouslySetInnerHTML`, sanitize it with DOMPurify.
- Add an import for `dompurify` in `MessageContent.tsx`.
- Wrap the output of `formatText(...).replace(...)` with `DOMPurify.sanitize()` before setting it as `__html`.
- No other functionality needs to change.

Implementation steps (all in `apps/web/src/components/chat/MessageContent.tsx`):

- Add `import DOMPurify from 'dompurify'` at the top of the file.
- Replace the code where `dangerouslySetInnerHTML` is used so that the HTML string is first sanitized with DOMPurify.
- No need to change the transformations themselves unless they’re expected to produce unsafe HTML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
