### PR TITLE
Potential fix for code scanning alert no. 13: Information exposure through an exception

### DIFF
--- a/src/app/ai/tools_router.py
+++ b/src/app/ai/tools_router.py
@@ -623,7 +623,7 @@ async def _openai_tools_orchestrator(
                 model=selected_model,
                 tools_count=len(tools),
             )
-            return f"Failed to process request: {e!s}"
+            return "An internal error occurred while processing the request."
         choices = first.get("choices", [])
         if not choices:
             logger.warning(


### PR DESCRIPTION
Potential fix for [https://github.com/b-franken/AzureDeployment_Ai/security/code-scanning/13](https://github.com/b-franken/AzureDeployment_Ai/security/code-scanning/13)

To fix this problem, we need to ensure that error messages returned to external users via the API never contain sensitive exception details, especially those generated in helper methods like `_openai_tools_orchestrator` in `src/app/ai/tools_router.py`. Specifically, in the error handling path of that method, instead of building error strings incorporating the actual exception text (as in `return f"Failed to process request: {e!s}"`), we should return a generic, non-sensitive error message such as `"An internal error occurred"`. Exception information should still be logged on the server for diagnostics.  

Files/regions/lines to change:
- In `src/app/ai/tools_router.py`, change all return statements that propagate error details to generic error strings. At a minimum, update the string in line 626 to a generic message (and similarly in other relevant places, such as direct tool command error responses, if applicable).

No changes are needed in the API route in `src/app/api/routes/deploy.py` since the error message is populated via the helper, except possibly to document or sanitize responses further if needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
